### PR TITLE
Ensure correct 200 status is sent to clients on successful listing

### DIFF
--- a/ngx_http_fancyindex_module.c
+++ b/ngx_http_fancyindex_module.c
@@ -762,7 +762,7 @@ ngx_http_fancyindex_handler(ngx_http_request_t *r)
 
     out[0].buf->last_in_chain = 1;
 
-    r->headers_out.status = NGX_OK;
+    r->headers_out.status = NGX_HTTP_OK;
     r->headers_out.content_type_len  = ngx_sizeof_ssz("text/html");
     r->headers_out.content_type.len  = ngx_sizeof_ssz("text/html");
     r->headers_out.content_type.data = (u_char *) "text/html";


### PR DESCRIPTION
Without this change, the resulting status sent to clients is 0 (NGX_OK). This ensures that when headers are sent to the client (line 770, immediately after setting the status), they don't sit there waiting forever.

I've tested this with Nginx 1.3.16 (latest at time of writing) and it works and solves #1.  I initially thought there was some issue with the keepalive or similar, but on closer inspection it was the incorrect status code.
