### PR TITLE
Fix typo in fancyindex_hide_symlinks that causes a crash.

### DIFF
--- a/ngx_http_fancyindex_module.c
+++ b/ngx_http_fancyindex_module.c
@@ -335,8 +335,8 @@ static ngx_command_t  ngx_http_fancyindex_commands[] = {
     { ngx_string("fancyindex_hide_symlinks"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
       ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_fancyindex_loc_conf_t, hide_symlinks),
-      0,
       NULL },
 
     { ngx_string("fancyindex_time_format"),


### PR DESCRIPTION
The recently added fancyindex_hide_symlinks change crashes if you try to use it due to an initialization error.  With a minor fix, the configuration option works great.