### PR TITLE
Fix hang when combining fancyindex with ngx_pagespeed

### DIFF
--- a/ngx_http_fancyindex_module.c
+++ b/ngx_http_fancyindex_module.c
@@ -1038,8 +1038,7 @@ ngx_http_fancyindex_handler(ngx_http_request_t *r)
     r->headers_out.content_type.data = (u_char *) "text/html";
 
     rc = ngx_http_send_header(r);
-
-    if (rc != NGX_OK || r->header_only)
+    if (rc == NGX_ERROR || rc > NGX_OK || r->header_only)
         return rc;
 
     if (alcf->header.len > 0) {


### PR DESCRIPTION
This attempts to address hanging requests when fancyindex is
combined with ngx_pagespeed. The change makes fancyindex check
the return value of ngx_http_send_header in a way that is just
the same as nginx's autoindex module - which makes the modules
work for me when I test with ngx_pagespeed.

Please take a good look!