### PR TITLE
Add the 'show_path' configuration directive

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -176,6 +176,19 @@ fancyindex_header
 .. note:: Using this directive needs the ngx_http_addition_module_ built
    into Nginx.
 
+fancyindex_show_path
+~~~~~~~~~~~~~~~~~
+:Syntax: *fancyindex_show_path* [*on* | *off*]
+:Default: fancyindex_show_path on
+:Context: http, server, location
+:Description:
+  Whether to output or not the path and the closing </h1> tag after the header.
+  This is useful when you want to handle the path displaying with a PHP script
+  for example.
+
+.. warning:: This directive can be turned off only if a custom header is provided
+   using fancyindex_header.
+
 fancyindex_ignore
 ~~~~~~~~~~~~~~~~~
 :Syntax: *fancyindex_ignore string1 [string2 [... stringN]]*

--- a/ngx_http_fancyindex_module.c
+++ b/ngx_http_fancyindex_module.c
@@ -152,6 +152,7 @@ typedef struct {
     ngx_flag_t exact_size;   /**< Sizes are sent always in bytes. */
     ngx_uint_t name_length;  /**< Maximum length of file names in bytes. */
     ngx_flag_t hide_symlinks;/**< Hide symbolic links in listings. */
+    ngx_flag_t show_path;    /**< Whether to display or not the path + '</h1>' after the header */
 
     ngx_str_t  header;       /**< File name for header, or empty if none. */
     ngx_str_t  footer;       /**< File name for footer, or empty if none. */
@@ -337,6 +338,13 @@ static ngx_command_t  ngx_http_fancyindex_commands[] = {
       ngx_conf_set_flag_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_fancyindex_loc_conf_t, hide_symlinks),
+      NULL },
+
+    { ngx_string("fancyindex_show_path"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_fancyindex_loc_conf_t, show_path),
       NULL },
 
     { ngx_string("fancyindex_time_format"),
@@ -711,13 +719,21 @@ make_content_buf(
     /*
      * Calculate needed buffer length.
      */
-    len = r->uri.len
-        + ngx_sizeof_ssz(t05_body2)
-        + ngx_sizeof_ssz(t06_list1)
-        + ngx_sizeof_ssz(t_parentdir_entry)
-        + ngx_sizeof_ssz(t07_list2)
-        + ngx_fancyindex_timefmt_calc_size (&alcf->time_format) * entries.nelts
-        ;
+    if (alcf->show_path)
+        len = r->uri.len
+          + ngx_sizeof_ssz(t05_body2)
+          + ngx_sizeof_ssz(t06_list1)
+          + ngx_sizeof_ssz(t_parentdir_entry)
+          + ngx_sizeof_ssz(t07_list2)
+          + ngx_fancyindex_timefmt_calc_size (&alcf->time_format) * entries.nelts
+          ;
+   else
+        len = r->uri.len
+          + ngx_sizeof_ssz(t06_list1)
+          + ngx_sizeof_ssz(t_parentdir_entry)
+          + ngx_sizeof_ssz(t07_list2)
+          + ngx_fancyindex_timefmt_calc_size (&alcf->time_format) * entries.nelts
+          ;
 
     /*
      * If we are a the root of the webserver (URI =  "/" --> length of 1),
@@ -845,8 +861,13 @@ make_content_buf(
                   sort_cmp_func);
     }
 
-    b->last = ngx_cpymem_str(b->last, r->uri);
-    b->last = ngx_cpymem_ssz(b->last, t05_body2);
+    /* Display the path, if needed */
+    if (alcf->show_path){
+        b->last = ngx_cpymem_str(b->last, r->uri);
+        b->last = ngx_cpymem_ssz(b->last, t05_body2);
+    }
+
+    /* Open the <table> tag */
     b->last = ngx_cpymem_ssz(b->last, t06_list1);
 
     tp = ngx_timeofday();
@@ -1319,6 +1340,7 @@ ngx_http_fancyindex_create_loc_conf(ngx_conf_t *cf)
     conf->exact_size    = NGX_CONF_UNSET;
     conf->ignore        = NGX_CONF_UNSET_PTR;
     conf->hide_symlinks = NGX_CONF_UNSET;
+    conf->show_path     = NGX_CONF_UNSET;
 
     return conf;
 }
@@ -1336,6 +1358,7 @@ ngx_http_fancyindex_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
     ngx_conf_merge_uint_value(conf->default_sort, prev->default_sort, NGX_HTTP_FANCYINDEX_SORT_CRITERION_NAME);
     ngx_conf_merge_value(conf->localtime, prev->localtime, 0);
     ngx_conf_merge_value(conf->exact_size, prev->exact_size, 1);
+    ngx_conf_merge_value(conf->show_path, prev->show_path, 1);
     ngx_conf_merge_uint_value(conf->name_length, prev->name_length, 50);
 
     ngx_conf_merge_str_value(conf->header, prev->header, "");
@@ -1345,6 +1368,13 @@ ngx_http_fancyindex_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_ptr_value(conf->ignore, prev->ignore, NULL);
     ngx_conf_merge_value(conf->hide_symlinks, prev->hide_symlinks, 0);
+
+    /* Just make sure we haven't disabled the show_path directive without providing a custom header */
+    if (conf->show_path == 0 && conf->header.len == 0)
+    {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "FancyIndex : cannot set show_path to off without providing a custom header !");
+        return NGX_CONF_ERROR;
+    }
 
     return NGX_CONF_OK;
 }


### PR DESCRIPTION
This directive enables someone using a custom header to disable the output of the indexed directory by the module.

Useful when you want to create links to previous directories via PHP for example.

This is a cleaner version of PR #24 . At least I learn how to use Git. :smile: 