### PR TITLE
Add fancyindex_directories_first config directive.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,6 +113,15 @@ fancyindex_default_sort
 :Description:
   Defines sorting criterion by default.
 
+fancyindex_directories_first
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:Syntax: *fancyindex_directories_first* [*on* | *off*]
+:Default: fancyindex_directories_first on
+:Context: http, server, location
+:Description:
+  If enabled (default setting), groups directories together and sorts them
+  before all regular files. If disabled, directories are sorted together with files.
+
 fancyindex_css_href
 ~~~~~~~~~~~~~~~~~~~
 :Syntax: *fancyindex_css_href uri*


### PR DESCRIPTION
Add the `fancyindex_directories_first` directive, which allows one to enable or disable grouping directories first before all files when sorting.  #40

This is accomplished by changing the sort function from `ngx_qsort` (which is the plain stdlib `qsort` under the hood) to `ngx_sort` which is a stable insertion sort (per `ngx_string.c`).

We call `ngx_sort` with the standard `sort_cmp_func` (albeit modified to remove grouping dirs), and then, if `fancyindex_directories_first` is set, call `ngx_sort` again with `ngx_http_fancyindex_cmp_entries_dirs_first` which sorts entries according to the directories first criterion.

Because a stable sorting function is used, the relative primary order is preserved when we call ngx_sort again.

Change int `(*sort_cmp_func) (const void*, const void*)` to `ngx_int_t (*sort_cmp_func) (const void*, const void*)` to satisfy `ngx_sort`.

If you have any issues with the pull request, please let me know and and I'll try to fix them.

Thanks!