### PR TITLE
Fix segfaults when opening directories with empty files

### DIFF
--- a/ngx_http_fancyindex_module.c
+++ b/ngx_http_fancyindex_module.c
@@ -997,7 +997,7 @@ make_content_buf(
 
                 /* If we are showing the filesize in bytes, do not show a decimal */
                 if (j == DIM(sizes) - 1)
-                    b->last = ngx_sprintf(b->last, "%d %s", length, sizes[j]);
+                    b->last = ngx_sprintf(b->last, "%O %s", length, sizes[j]);
                 else
                     b->last = ngx_sprintf(b->last, "%.1f %s", 
                                           (float) length / multiplier, sizes[j]);


### PR DESCRIPTION
Apparently ngx_sprintf does not tolerate format specifiers
not matching their corresponding argument types.