### PR TITLE
Update link for the 2nd theme example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,10 +109,9 @@ achieved using the module:
 * `Theme <https://github.com/TheInsomniac/Nginx-Fancyindex-Theme>`__ by
   `@TheInsomniac <https://github.com/TheInsomniac>`__. Uses custom header and
   footer.
-* `Theme <https://github.com/nwrd/Nginx-Fancyindex-Theme>`__ by
-  nwrd <https://github.com/nwrd>`__. Uses custom header and footer, the
-  header includes search field to filter by filename using JavaScript
-  (`demo <http://nwrd.sly.io/>`__).
+* `Theme <https://github.com/Naereen/Nginx-Fancyindex-Theme>`__ by
+  `Naereen <https://github.com/Naereen/>`__. Uses custom header and footer, the
+  header includes search field to filter by filename using JavaScript.
 
 
 Directives


### PR DESCRIPTION
The linked project (and example) was dead. Mine is not. (https://github.com/Naereen/Nginx-Fancyindex-Theme)