### PR TITLE
Fix sorting by file size for sizes bigger than INT_MAX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Fixed
+- Sorting by file size now also works correctly for directories which contain
+  files of sizes bigger than `INT_MAX`. (Bug report by and fix suggestion by
+  Chris Young.)
 
 ## [0.4.1] - 2016-08-18
 ### Added

--- a/ngx_http_fancyindex_module.c
+++ b/ngx_http_fancyindex_module.c
@@ -1229,7 +1229,7 @@ ngx_http_fancyindex_cmp_entries_size_desc(const void *one, const void *two)
     ngx_http_fancyindex_entry_t *first = (ngx_http_fancyindex_entry_t *) one;
     ngx_http_fancyindex_entry_t *second = (ngx_http_fancyindex_entry_t *) two;
 
-    return (int) (second->size - first->size);
+    return (first->size > second->size) - (first->size < second->size);
 }
 
 
@@ -1259,7 +1259,7 @@ ngx_http_fancyindex_cmp_entries_size_asc(const void *one, const void *two)
     ngx_http_fancyindex_entry_t *first = (ngx_http_fancyindex_entry_t *) one;
     ngx_http_fancyindex_entry_t *second = (ngx_http_fancyindex_entry_t *) two;
 
-    return (int) (first->size - second->size);
+    return (first->size > second->size) - (first->size < second->size);
 }
 
 


### PR DESCRIPTION
Instead of directly return the difference of the sizes from the comparison functions, use the relational operators, as suggested by @shric (Thanks!).

Fixes #74