### PR TITLE
add class names to table cells for better css formatting options

### DIFF
--- a/ngx_http_fancyindex_module.c
+++ b/ngx_http_fancyindex_module.c
@@ -772,7 +772,7 @@ make_content_buf(
          *     <td>size</td><td>date</td>
          *   </tr>
          */
-        len += ngx_sizeof_ssz("<tr><td><a href=\"")
+        len += ngx_sizeof_ssz("<tr><td class=\"link\"><a href=\"")
             + entry[i].name.len + entry[i].escape /* Escaped URL */
             + ngx_sizeof_ssz("?C=x&amp;O=y") /* URL sorting arguments */
             + ngx_sizeof_ssz("\" title=\"")
@@ -780,9 +780,9 @@ make_content_buf(
             + ngx_sizeof_ssz("\">")
             + entry[i].name.len + entry[i].utf_len
             + alcf->name_length + ngx_sizeof_ssz("&gt;")
-            + ngx_sizeof_ssz("</a></td><td>")
+            + ngx_sizeof_ssz("</a></td><td class=\"size\">")
             + 20 /* File size */
-            + ngx_sizeof_ssz("</td><td>")    /* Date prefix */
+            + ngx_sizeof_ssz("</td><td class=\"date\">")    /* Date prefix */
             + ngx_sizeof_ssz("</td></tr>\n") /* Date suffix */
             + 2 /* CR LF */
             ;
@@ -904,7 +904,7 @@ make_content_buf(
     if (r->uri.len > 1) {
         b->last = ngx_cpymem_ssz(b->last,
                                  "<tr>"
-                                 "<td><a href=\"../");
+                                 "<td class=\"link\"><a href=\"../");
         if (*sort_url_args) {
             b->last = ngx_cpymem(b->last,
                                  sort_url_args,
@@ -912,14 +912,14 @@ make_content_buf(
         }
         b->last = ngx_cpymem_ssz(b->last,
                                  "\">Parent directory/</a></td>"
-                                 "<td>-</td>"
-                                 "<td>-</td>"
+                                 "<td class=\"size\">-</td>"
+                                 "<td class=\"date\">-</td>"
                                  "</tr>");
     }
 
     /* Entries for directories and files */
     for (i = 0; i < entries.nelts; i++) {
-        b->last = ngx_cpymem_ssz(b->last, "<tr><td><a href=\"");
+        b->last = ngx_cpymem_ssz(b->last, "<tr><td class=\"link\"><a href=\"");
 
         if (entry[i].escape) {
             ngx_fancyindex_escape_uri(b->last,
@@ -967,7 +967,7 @@ make_content_buf(
         }
 
         if (len > alcf->name_length) {
-            b->last = ngx_cpymem_ssz(last, "..&gt;</a></td><td>");
+            b->last = ngx_cpymem_ssz(last, "..&gt;</a></td><td class=\"size\">");
 
         } else {
             if (entry[i].dir && alcf->name_length - len > 0) {
@@ -975,7 +975,7 @@ make_content_buf(
                 len++;
             }
 
-            b->last = ngx_cpymem_ssz(b->last, "</a></td><td>");
+            b->last = ngx_cpymem_ssz(b->last, "</a></td><td class=\"size\">");
         }
 
         if (alcf->exact_size) {
@@ -1005,7 +1005,7 @@ make_content_buf(
         }
 
         ngx_gmtime(entry[i].mtime + tp->gmtoff * 60 * alcf->localtime, &tm);
-        b->last = ngx_cpymem_ssz(b->last, "</td><td>");
+        b->last = ngx_cpymem_ssz(b->last, "</td><td class=\"date\">");
         b->last = ngx_fancyindex_timefmt(b->last, &alcf->time_format, &tm);
         b->last = ngx_cpymem_ssz(b->last, "</td></tr>");
 


### PR DESCRIPTION
Hi,

it would be easier to target the various table cells with CSS - and thus creating themes/custom designs easier - if the <td> elements had class names attached to them. This patch does not touch functionality just adds some meaningful classes.
