### PR TITLE
Switch mainline Nginx to 0.15.0, update older versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,15 @@ compiler:
 
 env:
   # Mainline.
-  - NGINX=1.13.12
-  - NGINX=1.13.12  DYNAMIC=1
+  - NGINX=1.15.0
+  - NGINX=1.15.0  DYNAMIC=1
   # Stable.
   - NGINX=1.14.0
   - NGINX=1.14.0  DYNAMIC=1
   # Other configurations.
   - NGINX=1.12.2
   - NGINX=1.12.2  DYNAMIC=1
-  - NGINX=1.11.6
-  - NGINX=1.10.2
+  - NGINX=1.10.3
   # Version 1.9.15 was the first with loadable module support.
   - NGINX=1.9.15
   - NGINX=1.9.15  DYNAMIC=1


### PR DESCRIPTION
In particular, version 1.11.6 does not even appear in the main download page. Of course the tarballs are still in the archives, but not being listed seems like a good criteria to remove it from the testing matrix. Also, change 1.10.2 to 1.10.3, which is the latest minor release from the series.