### PR TITLE
Mention awk fails on macOS and provide a solution

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -21,4 +21,9 @@ is known to work flawlessly. Just do:
     $ awk -f template.awk template.html > template.h
 
 If your copy of `awk` is not the GNU implementation, you will need to
-install it and use `gawk` instead in the command line above.
+install it and use `gawk` instead in the command line above. 
+
+This includes macOS where the current built-in `awk` (currently version
+20070501 at time of testing on 10.13.6) doesn't apply correctly and causes
+characters to be omitted from the output. `gawk` can be installed with a 
+package manager such as [Homebrew](https://brew.sh).


### PR DESCRIPTION
This adds a little bit of text to the HACKING.md doc about what to expect when editing the template on a Mac.