### PR TITLE
Add `fancyindex_hide_parent_dir` config directive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /t/*.sh
 /t/*.out
 /t/*.err
+/t/pup*
+/t/bug*/
+/prefix/

--- a/README.rst
+++ b/README.rst
@@ -247,6 +247,14 @@ fancyindex_hide_symlinks
 :Description:
   When enabled, generated listings will not contain symbolic links.
 
+fancyindex_hide_parent_dir
+~~~~~~~~~~~~~~~~~~~~~~~~
+:Syntax: *fancyindex_hide_parent_dir* [*on* | *off*]
+:Default: fancyindex_hide_parent_dir off
+:Context: http, server, location
+:Description:
+  When enabled, it will not show parent directory.
+
 fancyindex_localtime
 ~~~~~~~~~~~~~~~~~~~~
 :Syntax: *fancyindex_localtime* [*on* | *off*]

--- a/t/06-hide_parent.test
+++ b/t/06-hide_parent.test
@@ -1,0 +1,23 @@
+#! /bin/bash
+cat <<---
+This test check the output using "fancyindex_hide_parent_dir on"
+--
+use pup
+nginx_start 'fancyindex_hide_parent_dir on;'
+
+content=$( fetch /child-directory/ )
+
+# Check page title
+[[ $(pup -p title text{} <<< "${content}") = "Index of /child-directory/" ]]
+
+# Check table headers
+[[ $(pup -n body table tbody tr:first-child td <<< "${content}") -eq 3 ]]
+{
+	read -r name_label
+	read -r size_label
+	read -r date_label
+} < <(  pup -p body table tbody tr:first-child td text{} <<< "${content}" )
+[[ ${name_label} != Parent\ Directory/ ]]
+[[ ${name_label} = empty-file.txt ]]
+[[ ${size_label} != - ]]
+[[ ${date_label} != - ]]


### PR DESCRIPTION
Add the `fancyindex_hide_parent_dir` directive. When enabled, hide the parent directory display.

This feature will be a way to hide on both "only for certain locations" or "all locations". #57 