### PR TITLE
Add CRLF after the 'Parent directory' line. This makes the output easier to parse.

### DIFF
--- a/ngx_http_fancyindex_module.c
+++ b/ngx_http_fancyindex_module.c
@@ -930,7 +930,8 @@ make_content_buf(
                                  "\">Parent directory/</a></td>"
                                  "<td class=\"size\">-</td>"
                                  "<td class=\"date\">-</td>"
-                                 "</tr>");
+                                 "</tr>"
+                                 CRLF);
     }
 
     /* Entries for directories and files */


### PR DESCRIPTION
This is required by OpenBSD:
```
>--- Log opened Mon Feb 10 14:44:52 2020
>14:44 -!- Irssi: #openbsd: Total of 798 nicks [1 ops, 0 halfops, 0 voices, 797 normal]
>14:44 -ChanServ(ChanServ@services.)- [#OpenBSD] Carefully explaining your problem is half the solution.
>14:50 < adc> hi all, is generation of the package mirror listings (e.g., https://mirrors.dotsrc.org/pub/OpenBSD/6.6/packages/amd64/) controlled by openbsd devs? The package repository parser (usr.sbin/pkg_add/OpenBSD/PackageRepository.pm) is tripped up when there is more than one 'href="' string on a line. See the problem for yourself by running `pkg_info -Q 0ad` on 6.5 and 6.6. I've come up with a fix for current, but
>14:56 < gaston> adc: see http://cvsweb.openbsd.org/cgi-bin/cvsweb/www/build/mirrors.dat?rev=1.601&content-type=text/x-cvsweb-markup&only_with_tag=HEAD
>14:56 < gaston> (the ME/MN entries for dotsrc mirror
>14:57 < gaston> that's a nonstandard directory index and nothing in pkg_add copes with such things..
```