### PR TITLE
Use ngx_qsort to sort files and directories

### DIFF
--- a/ngx_http_fancyindex_module.c
+++ b/ngx_http_fancyindex_module.c
@@ -231,17 +231,17 @@ typedef struct {
 
 static ngx_int_t ngx_libc_cdecl
     ngx_http_fancyindex_cmp_entries_dirs_first(const void *one, const void *two);
-static ngx_int_t ngx_libc_cdecl
+static int ngx_libc_cdecl
     ngx_http_fancyindex_cmp_entries_name_desc(const void *one, const void *two);
-static ngx_int_t ngx_libc_cdecl
+static int ngx_libc_cdecl
     ngx_http_fancyindex_cmp_entries_size_desc(const void *one, const void *two);
-static ngx_int_t ngx_libc_cdecl
+static int ngx_libc_cdecl
     ngx_http_fancyindex_cmp_entries_mtime_desc(const void *one, const void *two);
-static ngx_int_t ngx_libc_cdecl
+static int ngx_libc_cdecl
     ngx_http_fancyindex_cmp_entries_name_asc(const void *one, const void *two);
-static ngx_int_t ngx_libc_cdecl
+static int ngx_libc_cdecl
     ngx_http_fancyindex_cmp_entries_size_asc(const void *one, const void *two);
-static ngx_int_t ngx_libc_cdecl
+static int ngx_libc_cdecl
     ngx_http_fancyindex_cmp_entries_mtime_asc(const void *one, const void *two);
 
 static ngx_int_t ngx_http_fancyindex_error(ngx_http_request_t *r,
@@ -567,7 +567,7 @@ make_content_buf(
 {
     ngx_http_fancyindex_entry_t *entry;
 
-    ngx_int_t (*sort_cmp_func) (const void*, const void*);
+    int (*sort_cmp_func)(const void *, const void *);
     const char  *sort_url_args = "";
 
     off_t        length;
@@ -1252,7 +1252,7 @@ ngx_http_fancyindex_cmp_entries_dirs_first(const void *one, const void *two)
 }
 
 
-static ngx_int_t ngx_libc_cdecl
+static int ngx_libc_cdecl
 ngx_http_fancyindex_cmp_entries_name_desc(const void *one, const void *two)
 {
     ngx_http_fancyindex_entry_t *first = (ngx_http_fancyindex_entry_t *) one;
@@ -1262,7 +1262,7 @@ ngx_http_fancyindex_cmp_entries_name_desc(const void *one, const void *two)
 }
 
 
-static ngx_int_t ngx_libc_cdecl
+static int ngx_libc_cdecl
 ngx_http_fancyindex_cmp_entries_size_desc(const void *one, const void *two)
 {
     ngx_http_fancyindex_entry_t *first = (ngx_http_fancyindex_entry_t *) one;
@@ -1272,7 +1272,7 @@ ngx_http_fancyindex_cmp_entries_size_desc(const void *one, const void *two)
 }
 
 
-static ngx_int_t ngx_libc_cdecl
+static int ngx_libc_cdecl
 ngx_http_fancyindex_cmp_entries_mtime_desc(const void *one, const void *two)
 {
     ngx_http_fancyindex_entry_t *first = (ngx_http_fancyindex_entry_t *) one;
@@ -1282,7 +1282,7 @@ ngx_http_fancyindex_cmp_entries_mtime_desc(const void *one, const void *two)
 }
 
 
-static ngx_int_t ngx_libc_cdecl
+static int ngx_libc_cdecl
 ngx_http_fancyindex_cmp_entries_name_asc(const void *one, const void *two)
 {
     ngx_http_fancyindex_entry_t *first = (ngx_http_fancyindex_entry_t *) one;
@@ -1292,7 +1292,7 @@ ngx_http_fancyindex_cmp_entries_name_asc(const void *one, const void *two)
 }
 
 
-static ngx_int_t ngx_libc_cdecl
+static int ngx_libc_cdecl
 ngx_http_fancyindex_cmp_entries_size_asc(const void *one, const void *two)
 {
     ngx_http_fancyindex_entry_t *first = (ngx_http_fancyindex_entry_t *) one;
@@ -1302,7 +1302,7 @@ ngx_http_fancyindex_cmp_entries_size_asc(const void *one, const void *two)
 }
 
 
-static ngx_int_t ngx_libc_cdecl
+static int ngx_libc_cdecl
 ngx_http_fancyindex_cmp_entries_mtime_asc(const void *one, const void *two)
 {
     ngx_http_fancyindex_entry_t *first = (ngx_http_fancyindex_entry_t *) one;

--- a/ngx_http_fancyindex_module.c
+++ b/ngx_http_fancyindex_module.c
@@ -229,8 +229,6 @@ typedef struct {
 
 
 
-static ngx_int_t ngx_libc_cdecl
-    ngx_http_fancyindex_cmp_entries_dirs_first(const void *one, const void *two);
 static int ngx_libc_cdecl
     ngx_http_fancyindex_cmp_entries_name_desc(const void *one, const void *two);
 static int ngx_libc_cdecl
@@ -1232,23 +1230,6 @@ add_builtin_header:
     }
 
     return (r != r->main) ? rc : ngx_http_send_special(r, NGX_HTTP_LAST);
-}
-
-static ngx_int_t ngx_libc_cdecl
-ngx_http_fancyindex_cmp_entries_dirs_first(const void *one, const void *two)
-{
-    ngx_http_fancyindex_entry_t *first = (ngx_http_fancyindex_entry_t *) one;
-    ngx_http_fancyindex_entry_t *second = (ngx_http_fancyindex_entry_t *) two;
-
-    /* move the directories to the start */
-    if (first->dir && !second->dir) {
-        return -1;
-    }
-    if (!first->dir && second->dir) {
-        return 1;
-    }
-
-    return 0;
 }
 
 

--- a/t/07-directory-first.test
+++ b/t/07-directory-first.test
@@ -1,0 +1,49 @@
+#! /bin/bash
+cat <<---
+This test check the output using "fancyindex_directories_first on"
+--
+
+for d in "008d" "000d" "004d" ; do
+	mkdir -p "${TESTDIR}/dir_first/${d}"
+done
+for f in "005f" "001f" "003f"; do
+	touch "${TESTDIR}/dir_first/${f}"
+done
+for d in "006d" "002d" ; do
+	mkdir -p "${TESTDIR}/dir_first/${d}"
+done
+
+nginx_start 'fancyindex_directories_first on;'
+previous=''
+cur_type=''
+while read -r name ; do
+	case "$name" in
+	*Parent*)
+		;;
+	*d*)
+		echo "dir $name"
+		[[ "$cur_type" = f ]] && fail 'Directories should come before Files'
+		cur_type=d
+		if [[ -z ${previous} ]] ; then
+			previous=${name}
+		else
+			[[ ${previous} < ${name} ]] || fail \
+				'Name %s should come before %s\n' "${previous}" "${name}"
+		fi
+		;;
+	*f*)
+		echo "file $name"
+		[[ -z "$cur_type" ]] && fail 'Directories should come before Files'
+		if [[ "$cur_type" = d ]] ; then
+			cur_type=f
+			previous=${name}
+		else
+			[[ ${previous} < ${name} ]] || fail \
+				'Name %s should come before %s\n' "${previous}" "${name}"
+		fi
+		;;
+	esac
+done < <( fetch '/dir_first/' \
+		| pup -p body table tbody 'td:nth-child(1)' text{} )
+
+nginx_is_running || fail "Nginx died"


### PR DESCRIPTION
`ngx_qsort` runs significantly faster than `ngx_sort`, especially when dealing with a directory containing 10000+ files.

When `fancyindex_directories_first` option is enabled, we can swap the files and directories before sorting them, avoiding stable but costly `ngx_sort`.