### PR TITLE
Load local header and footer files when configuring

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -182,13 +182,15 @@ fancyindex_name_length
 
 fancyindex_footer
 ~~~~~~~~~~~~~~~~~
-:Syntax: *fancyindex_footer path*
+:Syntax: *fancyindex_footer path* [*subrequest* | *local*]
 :Default: fancyindex_footer ""
 :Context: http, server, location
 :Description:
   Specifies which file should be inserted at the foot of directory listings.
   If set to an empty string, the default footer supplied by the module will
-  be sent.
+  be sent. The optional parameter indicates whether the *path* is to be
+  treated as an URI to load using a *subrequest* (the default), or whether
+  it refers to a *local* file.
 
 .. note:: Using this directive needs the ngx_http_addition_module_ built
    into Nginx.
@@ -203,13 +205,15 @@ fancyindex_footer
 
 fancyindex_header
 ~~~~~~~~~~~~~~~~~
-:Syntax: *fancyindex_header path*
+:Syntax: *fancyindex_header path* [*subrequest* | *local*]
 :Default: fancyindex_header ""
 :Context: http, server, location
 :Description:
   Specifies which file should be inserted at the head of directory listings.
   If set to an empty string, the default header supplied by the module will
-  be sent.
+  be sent. The optional parameter indicates whether the *path* is to be
+  treated as an URI to load using a *subrequest* (the default), or whether
+  it refers to a *local* file.
 
 .. note:: Using this directive needs the ngx_http_addition_module_ built
    into Nginx.

--- a/t/08-local-footer.test
+++ b/t/08-local-footer.test
@@ -1,0 +1,17 @@
+#! /bin/bash
+cat <<---
+This test checks that a local footer can be included with
+"fancyindex_header ... local"
+--
+use pup
+
+cat > "${TESTDIR}/footer" <<EOF
+<div id="customfooter">yes</div>
+EOF
+
+nginx_start 'fancyindex_footer "/footer" local;'
+
+T=$(fetch / | pup -p body 'div#customfooter' text{})
+[[ $T == yes ]] ||  fail 'Custom header missing'
+
+nginx_is_running || fail 'Nginx died'

--- a/t/09-local-header.test
+++ b/t/09-local-header.test
@@ -1,0 +1,17 @@
+#! /bin/bash
+cat <<---
+This test checks that a local header can be included with
+"fancyindex_header ... local"
+--
+use pup
+
+cat > "${TESTDIR}/header" <<EOF
+<div id="customheader">yes</div>
+EOF
+
+nginx_start 'fancyindex_header "/header" local;'
+
+T=$(fetch / | pup -p body 'div#customheader' text{})
+[[ $T == yes ]] ||  fail 'Custom header missing'
+
+nginx_is_running || fail 'Nginx died'

--- a/t/10-local-headerfooter.test
+++ b/t/10-local-headerfooter.test
@@ -1,0 +1,26 @@
+#! /bin/bash
+cat <<---
+This test checks that both a local header and footer can be included with
+"fancyindex_{header,footer} ... local"
+--
+use pup
+
+cat > "${TESTDIR}/header" <<EOF
+<div id="customheader">yes</div>
+EOF
+cat > "${TESTDIR}/footer" <<EOF
+<div id="customfooter">yes</div>
+EOF
+
+nginx_start 'fancyindex_header "/header" local;
+             fancyindex_footer "/footer" local;'
+
+P=$(fetch /)
+
+H=$(pup -p body 'div#customheader' text{} <<< "$P")
+[[ $H == yes ]] ||  fail 'Custom header missing'
+
+F=$(pup -p body 'div#customfooter' text{} <<< "$P")
+[[ $F == yes ]] || fail 'Custom footer missing'
+
+nginx_is_running || fail 'Nginx died'

--- a/t/11-local-footer-nested.test
+++ b/t/11-local-footer-nested.test
@@ -1,0 +1,31 @@
+#! /bin/bash
+cat <<---
+This test checks that local footers are correctly included in presence of
+directives in nested locations:
+
+	fancyindex_footer <one> local;
+	location /sub {
+		fancyindex_footer <another> local;
+	}
+
+--
+use pup
+
+echo '<div id="topfooter">yes</div>' > "${TESTDIR}/top-footer"
+echo '<div id="subfooter">yes</div>' > "${TESTDIR}/sub-footer"
+
+nginx_start 'fancyindex_footer "/top-footer" local;
+             location /child-directory {
+			    fancyindex_footer "/sub-footer" local;
+			 }'
+
+T=$(fetch /)
+echo "$T" > "$TESTDIR/top.html"
+[[ $(pup -p body 'div#topfooter' text{} <<< "$T") = yes ]] || fail 'Custom header missing at /'
+[[ -z $(pup -p body 'div#subfooter' text{} <<< "$T") ]] || fail 'Wrong header at /'
+
+T=$(fetch /child-directory/)
+[[ $(pup -p body 'div#subfooter' text{} <<< "$T") = yes ]] || fail 'Custom header missing at /sub/'
+[[ -z $(pup -p body 'div#topfooter' text{} <<< "$T") ]] || fail 'Wrong header at /sub/'
+
+nginx_is_running || fail 'Nginx died'


### PR DESCRIPTION
Make the configuration process load the local files specified with `fancyindex_{header,footer} "foo" local`, instead of loading them on every request.

Additionally, change the syntax of the configuration directive to accept an optional parameter indicating whether the header (or footer) is to be loaded as a subrequest (default, for backwards compatibility) or a local file (must be specified explicitly). This avoids the footgun of having a local file which accidentally happens to match the subrequest that one had the intention to do when configuring.

----

This is a follow-up to #83