### PR TITLE
docs: fix simple typo, configration -> configuration

### DIFF
--- a/ngx_http_fancyindex_module.c
+++ b/ngx_http_fancyindex_module.c
@@ -496,8 +496,8 @@ static ngx_http_module_t  ngx_http_fancyindex_module_ctx = {
     NULL,                                  /* create server configuration */
     NULL,                                  /* merge server configuration */
 
-    ngx_http_fancyindex_create_loc_conf,   /* create location configration */
-    ngx_http_fancyindex_merge_loc_conf     /* merge location configration */
+    ngx_http_fancyindex_create_loc_conf,   /* create location configuration */
+    ngx_http_fancyindex_merge_loc_conf     /* merge location configuration */
 };
 
 


### PR DESCRIPTION
There is a small typo in ngx_http_fancyindex_module.c.

Should read `configuration` rather than `configration`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md