### PR TITLE
Add case insensitive name sorting support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,6 +142,15 @@ fancyindex_default_sort
 :Description:
   Defines sorting criterion by default.
 
+fancyindex_case_sensitive
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:Syntax: *fancyindex_case_sensitive* [*on* | *off*]
+:Default: fancyindex_case_sensitive on
+:Context: http, server, location
+:Description:
+  If enabled (default setting), sorting by name will be case sensitive.
+  If disabled, case will be ignored when applying a sort by name.
+
 fancyindex_directories_first
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 :Syntax: *fancyindex_directories_first* [*on* | *off*]


### PR DESCRIPTION
Add the fancyindex_case_sensitive option which considers the case when sorting by name if it is "on" (default option to keep current behavior) and does a case insensitive name sorting if it is "off". Tested on Ubuntu 20.04.1 LTS with Nginx 1.19.6 