### PR TITLE
template.awk: Fix name of HACKING file

### DIFF
--- a/template.awk
+++ b/template.awk
@@ -3,7 +3,7 @@
 # Copyright © Adrian Perez <aperez@igalia.com>
 #
 # Converts an HTML template into a C header suitable for inclusion.
-# Take a look at the HACKING.rst file to know how to use it :-)
+# Take a look at the HACKING.md file to know how to use it :-)
 #
 # This code is placed in the public domain.
 


### PR DESCRIPTION
HACKING was converted from reStructuredText to markdown back in 2014 in 0064164d4ee9750a9a218d2cdf4fd9cb6ec07ca6.