### PR TITLE
get-pup: Verify with openssl instead of sha256sum

### DIFF
--- a/t/get-pup
+++ b/t/get-pup
@@ -66,7 +66,7 @@ done <<< "${SHASUMS}"
 
 wget -cO "${TDIR}/${ZIPFILE}" "${BASEURL}/${ZIPFILE}"
 
-read -r GOT_SHA _ < <( sha256sum "${TDIR}/${ZIPFILE}" )
+read -r _ GOT_SHA < <( openssl sha256 < "${TDIR}/${ZIPFILE}" )
 if [[ ${EXPECT_SHA} = ${GOT_SHA} ]] ; then
 	echo "Checksum for ${ZIPFILE} verified :-)"
 else


### PR DESCRIPTION
Use `openssl` to verify download because `sha256sum` does not exist on macOS.

If there are systems that have `sha256sum` but not `openssl`, then this could be rewritten to use whichever of those is present.