### PR TITLE
Tests: Build nginx in parallel on macOS

### DIFF
--- a/t/build-and-run
+++ b/t/build-and-run
@@ -12,6 +12,15 @@ if [[ $2 -eq 1 ]] ; then
 	readonly DYNAMIC=$2
 fi
 
+case $(uname -s) in
+	Darwin)
+		JOBS=$(sysctl -n hw.activecpu)
+		;;
+	*)
+		JOBS=1
+		;;
+esac
+
 cd "$(dirname "$0")/.."
 wget -O - http://nginx.org/download/nginx-${NGINX}.tar.gz | tar -xzf -
 rm -rf prefix/
@@ -20,6 +29,7 @@ cd nginx-${NGINX}
 	--add-${DYNAMIC:+dynamic-}module=.. \
 	--with-http_addition_module \
 	--prefix="$(pwd)/../prefix"
+make -j"$JOBS"
 make install
 cd ..
 exec ./t/run prefix ${DYNAMIC}


### PR DESCRIPTION
When running `./build-and-run` it took so many seconds to build nginx! This PR makes it faster by building in parallel using all available CPUs. I only filled in the code to get the right number of CPUs for macOS since that's all I'm familiar with; I leave it as a task for other contributors to add the necessary code to detect it on other operating systems ([`nproc`](https://man7.org/linux/man-pages/man1/nproc.1.html)?).