### PR TITLE
Draft: Add table sort classes and aria-sort attribute

### DIFF
--- a/ngx_http_fancyindex_module.c
+++ b/ngx_http_fancyindex_module.c
@@ -617,10 +617,10 @@ make_header_buf(ngx_http_request_t *r, const ngx_str_t css_href)
 {
     ngx_buf_t *b;
     size_t blen = r->uri.len
-        + ngx_sizeof_ssz(t01_head1)
-        + ngx_sizeof_ssz(t02_head2)
-        + ngx_sizeof_ssz(t03_head3)
-        + ngx_sizeof_ssz(t04_body1)
+        + ngx_sizeof_ssz(t_head1)
+        + ngx_sizeof_ssz(t_head2)
+        + ngx_sizeof_ssz(t_head3)
+        + ngx_sizeof_ssz(t_body1)
         ;
 
     if (css_href.len) {
@@ -633,7 +633,7 @@ make_header_buf(ngx_http_request_t *r, const ngx_str_t css_href)
     if ((b = ngx_create_temp_buf(r->pool, blen)) == NULL)
         return NULL;
 
-    b->last = ngx_cpymem_ssz(b->last, t01_head1);
+    b->last = ngx_cpymem_ssz(b->last, t_head1);
 
     if (css_href.len) {
         b->last = ngx_cpymem_str(b->last, css_href_pre);
@@ -641,10 +641,10 @@ make_header_buf(ngx_http_request_t *r, const ngx_str_t css_href)
         b->last = ngx_cpymem_str(b->last, css_href_post);
     }
 
-    b->last = ngx_cpymem_ssz(b->last, t02_head2);
+    b->last = ngx_cpymem_ssz(b->last, t_head2);
     b->last = ngx_cpymem_str(b->last, r->uri);
-    b->last = ngx_cpymem_ssz(b->last, t03_head3);
-    b->last = ngx_cpymem_ssz(b->last, t04_body1);
+    b->last = ngx_cpymem_ssz(b->last, t_head3);
+    b->last = ngx_cpymem_ssz(b->last, t_body1);
 
     return b;
 }
@@ -851,17 +851,17 @@ make_content_buf(
 
     if (alcf->show_path)
         len = r->uri.len + escape_html
-          + ngx_sizeof_ssz(t05_body2)
-          + ngx_sizeof_ssz(t06_list1)
+          + ngx_sizeof_ssz(t_body2)
+          + ngx_sizeof_ssz(t_list_begin)
           + ngx_sizeof_ssz(t_parentdir_entry)
-          + ngx_sizeof_ssz(t07_list2)
+          + ngx_sizeof_ssz(t_list_end)
           + ngx_fancyindex_timefmt_calc_size (&alcf->time_format) * entries.nelts
           ;
    else
         len = r->uri.len + escape_html
-          + ngx_sizeof_ssz(t06_list1)
+          + ngx_sizeof_ssz(t_list_begin)
           + ngx_sizeof_ssz(t_parentdir_entry)
-          + ngx_sizeof_ssz(t07_list2)
+          + ngx_sizeof_ssz(t_list_end)
           + ngx_fancyindex_timefmt_calc_size (&alcf->time_format) * entries.nelts
           ;
 
@@ -1025,11 +1025,11 @@ make_content_buf(
     /* Display the path, if needed */
     if (alcf->show_path){
         b->last = last = (u_char *) ngx_escape_html(b->last, r->uri.data, r->uri.len);
-        b->last = ngx_cpymem_ssz(b->last, t05_body2);
+        b->last = ngx_cpymem_ssz(b->last, t_body2);
     }
 
     /* Open the <table> tag */
-    b->last = ngx_cpymem_ssz(b->last, t06_list1);
+    b->last = ngx_cpymem_ssz(b->last, t_list_begin);
 
     tp = ngx_timeofday();
 
@@ -1129,7 +1129,7 @@ make_content_buf(
     }
 
     /* Output table bottom */
-    b->last = ngx_cpymem_ssz(b->last, t07_list2);
+    b->last = ngx_cpymem_ssz(b->last, t_list_end);
 
     *pb = b;
     return NGX_OK;
@@ -1259,8 +1259,8 @@ add_builtin_header:
             out[last].buf->pos = alcf->footer.local.data;
             out[last].buf->last = alcf->footer.local.data + alcf->footer.local.len;
         } else {
-            out[last].buf->pos = (u_char*) t08_foot1;
-            out[last].buf->last = (u_char*) t08_foot1 + sizeof(t08_foot1) - 1;
+            out[last].buf->pos = (u_char*) t_foot;
+            out[last].buf->last = (u_char*) t_foot + sizeof(t_foot) - 1;
         }
 
         out[last-1].buf->last_in_chain = 0;
@@ -1321,8 +1321,8 @@ add_builtin_header:
         if (out[0].buf == NULL)
             return NGX_ERROR;
         out[0].buf->memory = 1;
-        out[0].buf->pos = (u_char*) t08_foot1;
-        out[0].buf->last = (u_char*) t08_foot1 + sizeof(t08_foot1) - 1;
+        out[0].buf->pos = (u_char*) t_foot;
+        out[0].buf->last = (u_char*) t_foot + sizeof(t_foot) - 1;
         out[0].buf->last_in_chain = 1;
         out[0].buf->last_buf = 1;
         /* Directly send out the builtin footer */

--- a/ngx_http_fancyindex_module.c
+++ b/ngx_http_fancyindex_module.c
@@ -853,6 +853,8 @@ make_content_buf(
         len = r->uri.len + escape_html
           + ngx_sizeof_ssz(t_body2)
           + ngx_sizeof_ssz(t_list_begin)
+          + ngx_sizeof_ssz(t_list_head)
+          + ngx_sizeof_ssz("desc sort-col-1")
           + ngx_sizeof_ssz(t_list_colhead_name1)
           + ngx_sizeof_ssz(t_list_colhead_name2)
           + ngx_sizeof_ssz(t_list_colhead_size1)
@@ -868,6 +870,8 @@ make_content_buf(
    else
         len = r->uri.len + escape_html
           + ngx_sizeof_ssz(t_list_begin)
+          + ngx_sizeof_ssz(t_list_head)
+          + ngx_sizeof_ssz("desc sort-col-1")
           + ngx_sizeof_ssz(t_list_colhead_name1)
           + ngx_sizeof_ssz(t_list_colhead_name2)
           + ngx_sizeof_ssz(t_list_colhead_size1)
@@ -1053,6 +1057,27 @@ make_content_buf(
 
     /* Open the <table> tag */
     b->last = ngx_cpymem_ssz(b->last, t_list_begin);
+    switch (sort_criterion) {
+        case NGX_HTTP_FANCYINDEX_SORT_CRITERION_NAME_DESC:
+            b->last = ngx_cpymem_ssz(b->last, "desc sort-col-1");
+            break;
+        case NGX_HTTP_FANCYINDEX_SORT_CRITERION_NAME:
+            b->last = ngx_cpymem_ssz(b->last, "asc sort-col-1");
+            break;
+        case NGX_HTTP_FANCYINDEX_SORT_CRITERION_SIZE_DESC:
+            b->last = ngx_cpymem_ssz(b->last, "desc sort-col-2");
+            break;
+        case NGX_HTTP_FANCYINDEX_SORT_CRITERION_SIZE:
+            b->last = ngx_cpymem_ssz(b->last, "asc sort-col-2");
+            break;
+        case NGX_HTTP_FANCYINDEX_SORT_CRITERION_DATE_DESC:
+            b->last = ngx_cpymem_ssz(b->last, "desc sort-col-3");
+            break;
+        case NGX_HTTP_FANCYINDEX_SORT_CRITERION_DATE:
+            b->last = ngx_cpymem_ssz(b->last, "asc sort-col-3");
+            break;
+    }
+    b->last = ngx_cpymem_ssz(b->last, t_list_head);
 
     /* Write the column headers */
     b->last = ngx_cpymem_ssz(b->last, t_list_colhead_name1);

--- a/template.h
+++ b/template.h
@@ -1,5 +1,5 @@
 /* Automagically generated, do not edit! */
-static const u_char t01_head1[] = ""
+static const u_char t_head1[] = ""
 "<!DOCTYPE html>"
 "<html>"
 "<head>"
@@ -44,24 +44,24 @@ static const u_char t01_head1[] = ""
 "</style>"
 "\n"
 ;
-static const u_char t02_head2[] = ""
+static const u_char t_head2[] = ""
 "\n"
 "<title>Index of "
 ;
-static const u_char t03_head3[] = ""
+static const u_char t_head3[] = ""
 "</title>"
 "\n"
 "</head>"
 ;
-static const u_char t04_body1[] = ""
+static const u_char t_body1[] = ""
 "<body>"
 "<h1>Index of "
 ;
-static const u_char t05_body2[] = ""
+static const u_char t_body2[] = ""
 "</h1>"
 "\n"
 ;
-static const u_char t06_list1[] = ""
+static const u_char t_list_begin[] = ""
 "<table id=\"list\">"
 "<thead>"
 "<tr>"
@@ -81,22 +81,22 @@ static const u_char t_parentdir_entry[] = ""
 "</tr>"
 "\n"
 ;
-static const u_char t07_list2[] = ""
+static const u_char t_list_end[] = ""
 "</tbody>"
 "</table>"
 ;
-static const u_char t08_foot1[] = ""
+static const u_char t_foot[] = ""
 "</body>"
 "</html>"
 ;
 #define NFI_TEMPLATE_SIZE (0 \
-	+ nfi_sizeof_ssz(t01_head1) \
-	+ nfi_sizeof_ssz(t02_head2) \
-	+ nfi_sizeof_ssz(t03_head3) \
-	+ nfi_sizeof_ssz(t04_body1) \
-	+ nfi_sizeof_ssz(t05_body2) \
-	+ nfi_sizeof_ssz(t06_list1) \
+	+ nfi_sizeof_ssz(t_head1) \
+	+ nfi_sizeof_ssz(t_head2) \
+	+ nfi_sizeof_ssz(t_head3) \
+	+ nfi_sizeof_ssz(t_body1) \
+	+ nfi_sizeof_ssz(t_body2) \
+	+ nfi_sizeof_ssz(t_list_begin) \
 	+ nfi_sizeof_ssz(t_parentdir_entry) \
-	+ nfi_sizeof_ssz(t07_list2) \
-	+ nfi_sizeof_ssz(t08_foot1) \
+	+ nfi_sizeof_ssz(t_list_end) \
+	+ nfi_sizeof_ssz(t_foot) \
 	)

--- a/template.h
+++ b/template.h
@@ -41,6 +41,21 @@ static const u_char t_head1[] = ""
 "text-overflow: '>';"
 "overflow: hidden;"
 "}"
+".sort-col-1 th:nth-of-type(1),"
+".sort-col-2 th:nth-of-type(2),"
+".sort-col-3 th:nth-of-type(3) {"
+"background:#ddd;"
+"}"
+".sort-col-1 td:nth-of-type(1),"
+".sort-col-2 td:nth-of-type(2),"
+".sort-col-3 td:nth-of-type(3) {"
+"background:#eee;"
+"}"
+".sort-col-1 tr:nth-child(even) td:nth-of-type(1),"
+".sort-col-2 tr:nth-child(even) td:nth-of-type(2),"
+".sort-col-3 tr:nth-child(even) td:nth-of-type(3) {"
+"background:#e4e4e4;"
+"}"
 "</style>"
 "\n"
 ;
@@ -62,7 +77,10 @@ static const u_char t_body2[] = ""
 "\n"
 ;
 static const u_char t_list_begin[] = ""
-"<table id=\"list\">"
+"<table id=\"list\" class=\""
+;
+static const u_char t_list_head[] = ""
+"\">"
 "<thead>"
 "<tr>"
 ;
@@ -113,6 +131,7 @@ static const u_char t_foot[] = ""
 	+ nfi_sizeof_ssz(t_body1) \
 	+ nfi_sizeof_ssz(t_body2) \
 	+ nfi_sizeof_ssz(t_list_begin) \
+	+ nfi_sizeof_ssz(t_list_head) \
 	+ nfi_sizeof_ssz(t_list_colhead_name1) \
 	+ nfi_sizeof_ssz(t_list_colhead_name2) \
 	+ nfi_sizeof_ssz(t_list_colhead_size1) \

--- a/template.h
+++ b/template.h
@@ -65,9 +65,26 @@ static const u_char t_list_begin[] = ""
 "<table id=\"list\">"
 "<thead>"
 "<tr>"
-"<th colspan=\"2\"><a href=\"?C=N&amp;O=A\">File Name</a>&nbsp;<a href=\"?C=N&amp;O=D\">&nbsp;&darr;&nbsp;</a></th>"
-"<th><a href=\"?C=S&amp;O=A\">File Size</a>&nbsp;<a href=\"?C=S&amp;O=D\">&nbsp;&darr;&nbsp;</a></th>"
-"<th><a href=\"?C=M&amp;O=A\">Date</a>&nbsp;<a href=\"?C=M&amp;O=D\">&nbsp;&darr;&nbsp;</a></th>"
+;
+static const u_char t_list_colhead_name1[] = ""
+"<th colspan=\"2\""
+;
+static const u_char t_list_colhead_name2[] = ""
+"><a href=\"?C=N&amp;O=A\">File Name</a>&nbsp;<a href=\"?C=N&amp;O=D\">&nbsp;&darr;&nbsp;</a></th>"
+;
+static const u_char t_list_colhead_size1[] = ""
+"<th"
+;
+static const u_char t_list_colhead_size2[] = ""
+"><a href=\"?C=S&amp;O=A\">File Size</a>&nbsp;<a href=\"?C=S&amp;O=D\">&nbsp;&darr;&nbsp;</a></th>"
+;
+static const u_char t_list_colhead_date1[] = ""
+"<th"
+;
+static const u_char t_list_colhead_date2[] = ""
+"><a href=\"?C=M&amp;O=A\">Date</a>&nbsp;<a href=\"?C=M&amp;O=D\">&nbsp;&darr;&nbsp;</a></th>"
+;
+static const u_char t_list_mid[] = ""
 "</tr>"
 "</thead>"
 "\n"
@@ -96,6 +113,13 @@ static const u_char t_foot[] = ""
 	+ nfi_sizeof_ssz(t_body1) \
 	+ nfi_sizeof_ssz(t_body2) \
 	+ nfi_sizeof_ssz(t_list_begin) \
+	+ nfi_sizeof_ssz(t_list_colhead_name1) \
+	+ nfi_sizeof_ssz(t_list_colhead_name2) \
+	+ nfi_sizeof_ssz(t_list_colhead_size1) \
+	+ nfi_sizeof_ssz(t_list_colhead_size2) \
+	+ nfi_sizeof_ssz(t_list_colhead_date1) \
+	+ nfi_sizeof_ssz(t_list_colhead_date2) \
+	+ nfi_sizeof_ssz(t_list_mid) \
 	+ nfi_sizeof_ssz(t_parentdir_entry) \
 	+ nfi_sizeof_ssz(t_list_end) \
 	+ nfi_sizeof_ssz(t_foot) \

--- a/template.html
+++ b/template.html
@@ -1,4 +1,4 @@
-<!-- var t01_head1 -->
+<!-- var t_head1 -->
 <!DOCTYPE html>
 <html>
 	<head>
@@ -42,24 +42,24 @@
 			}
 		</style>
 
-<!-- var t02_head2 -->
+<!-- var t_head2 -->
 
 		<title>Index of 
 <!-- var NONE -->
 			/path/to/somewhere
-<!-- var t03_head3 -->
+<!-- var t_head3 -->
 		</title>
 
 	</head>
-<!-- var t04_body1 -->
+<!-- var t_body1 -->
 	<body>
 		<h1>Index of 
 <!-- var NONE -->
 			/path/to/somewhere
-<!-- var t05_body2 -->
+<!-- var t_body2 -->
 		</h1>
 
-<!-- var t06_list1 -->
+<!-- var t_list_begin -->
 		<table id="list">
 			<thead>
 				<tr>
@@ -93,9 +93,9 @@
 					<td>666</td>
 					<td>date</td>
 				</tr>
-<!-- var t07_list2 -->
+<!-- var t_list_end -->
 			</tbody>
 		</table>
-<!-- var t08_foot1 -->
+<!-- var t_foot -->
 	</body>
 </html>

--- a/template.html
+++ b/template.html
@@ -63,9 +63,19 @@
 		<table id="list">
 			<thead>
 				<tr>
-					<th colspan="2"><a href="?C=N&amp;O=A">File Name</a>&nbsp;<a href="?C=N&amp;O=D">&nbsp;&darr;&nbsp;</a></th>
-					<th><a href="?C=S&amp;O=A">File Size</a>&nbsp;<a href="?C=S&amp;O=D">&nbsp;&darr;&nbsp;</a></th>
-					<th><a href="?C=M&amp;O=A">Date</a>&nbsp;<a href="?C=M&amp;O=D">&nbsp;&darr;&nbsp;</a></th>
+<!-- var t_list_colhead_name1 -->
+					<th colspan="2"
+<!-- var t_list_colhead_name2 -->
+><a href="?C=N&amp;O=A">File Name</a>&nbsp;<a href="?C=N&amp;O=D">&nbsp;&darr;&nbsp;</a></th>
+<!-- var t_list_colhead_size1 -->
+					<th
+<!-- var t_list_colhead_size2 -->
+><a href="?C=S&amp;O=A">File Size</a>&nbsp;<a href="?C=S&amp;O=D">&nbsp;&darr;&nbsp;</a></th>
+<!-- var t_list_colhead_date1 -->
+					<th
+<!-- var t_list_colhead_date2 -->
+><a href="?C=M&amp;O=A">Date</a>&nbsp;<a href="?C=M&amp;O=D">&nbsp;&darr;&nbsp;</a></th>
+<!-- var t_list_mid -->
 				</tr>
 			</thead>
 

--- a/template.html
+++ b/template.html
@@ -40,6 +40,21 @@
 				text-overflow: '>';
 				overflow: hidden;
 			}
+			.sort-col-1 th:nth-of-type(1),
+			.sort-col-2 th:nth-of-type(2),
+			.sort-col-3 th:nth-of-type(3) {
+				background:#ddd;
+			}
+			.sort-col-1 td:nth-of-type(1),
+			.sort-col-2 td:nth-of-type(2),
+			.sort-col-3 td:nth-of-type(3) {
+				background:#eee;
+			}
+			.sort-col-1 tr:nth-child(even) td:nth-of-type(1),
+			.sort-col-2 tr:nth-child(even) td:nth-of-type(2),
+			.sort-col-3 tr:nth-child(even) td:nth-of-type(3) {
+				background:#e4e4e4;
+			}
 		</style>
 
 <!-- var t_head2 -->
@@ -60,7 +75,11 @@
 		</h1>
 
 <!-- var t_list_begin -->
-		<table id="list">
+		<table id="list" class="
+<!-- var NONE -->
+asc sort-col-1
+<!-- var t_list_head -->
+">
 			<thead>
 				<tr>
 <!-- var t_list_colhead_name1 -->


### PR DESCRIPTION
This PR works for me but I'm marking it as a draft because it may require more discussion before merging to decide the best approach.

I wanted to be able to apply a CSS style to the currently-sorted column but there didn't seem to be a way to do it (without JavaScript). This PR adds two classes to the `table` tag: one for sort criterion, one for sort direction/order. I also updated the template to use the sort criterion classes to shade the currently-sorted column a little darker.

I debated for awhile about what specific class names to use for the sort criterion. I couldn't determine if there was an established standard for that sort of thing. For now it uses numbered classes (e.g. `sort-col-1`) because that goes nicely with the way the CSS selector to target the column header has to be written (e.g. `.sort-col-1 th:nth-of-type(1)`). However, `nth-of-type` only has to be used because the column headers don't have any classes. (This also came up in #133.) Ideally I would like to add the classes that are already used in the table cells to the column headers as well. That will result in a slight confusion where the header of the name column has the class `link`. If it were up to me I would change class `link` everywhere to be class `name`. That would be a breaking change, but if the plan is to release a new major version next, like 0.6.0 or even 1.0.0, a breaking change should be ok if communicated clearly in the release notes. (Making a breaking change after 1.0.0 is less desirable.) If the class were renamed and classes were applied to the column headers as well, then `nth-of-type` wouldn't be needed anymore and the sort column class names could be changed from numbered to named (e.g. `sort-by-name`) and the CSS selector to style the column could be simplified to `.sort-by-name .name`). Using named rather than numbered classes would be advantageous if there is a desire to apply styles to specific columns (for example, to align the size column to the right) and also to allow the order of the columns to be changed (requested in #66).

In searching for a standard way to indicate table sort order I came across the [`aria-sort`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-sort) attribute intended originally for screen readers but also addressable from CSS. Initially this seemed perfect, so I implemented it first, but then realized that since this attribute is only set on the `th` tag, it cannot be used to style the corresponding `td` tags, so I still added the classes to the `table` tag as well.

Let me know if you have thoughts or concerns about any of the above or about what I've committed so far.