### PR TITLE
.gitignore: Ignore nginx-*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.sw[op]
+/nginx-*
 /t/*.sh
 /t/*.out
 /t/*.err


### PR DESCRIPTION
After running `t/build-and-run` an nginx directory is left in the main directory. Hide this from `git status` since we won't want to check it in.