### PR TITLE
CI: Add macOS test runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [macos-latest, ubuntu-18.04]
         compiler: [gcc, clang]
-        dynamic: [0, 1]
         nginx:
           # Mainline
           - 1.21.6
@@ -18,10 +18,15 @@ jobs:
           - 1.9.15
           # Oldest supported version.
           - 0.8.55
+        dynamic: [0, 1]
         exclude:
           - nginx: 0.8.55
             dynamic: 1
-    runs-on: ubuntu-18.04
+          - nginx: 0.8.55
+            os: macos-latest
+          - compiler: gcc
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
     env:
       CFLAGS: "-Wno-error"
     steps:
@@ -29,12 +34,16 @@ jobs:
         uses: actions/checkout@v2
       - name: Install Packages
         run: |
-          sudo apt update
-          sudo apt install -y libpcre3-dev libssl-dev
+          case $RUNNER_OS in
+            Linux )
+              sudo apt update
+              sudo apt install -y libpcre3-dev libssl-dev
+              ;;
+            * )
+              ;;
+          esac
           t/get-pup || echo 'Tests needing pup will be skipped'
       - name: Test
         env:
           CC: ${{ matrix.compiler }}
-        run: |
-          CC=${{ matrix.compiler }}
-          t/build-and-run ${{ matrix.nginx }} ${{ matrix.dynamic }}
+        run: t/build-and-run ${{ matrix.nginx }} ${{ matrix.dynamic }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
         dynamic: [0, 1]
         nginx:
           # Mainline
-          - 1.21.3
+          - 1.21.6
           # Stable.
-          - 1.20.1
+          - 1.20.2
           # First version with loadable module support.
           - 1.9.15
           # Oldest supported version.


### PR DESCRIPTION
This adds macOS test runners which were requested in a comment in #140.

I excluded the oldest nginx version, 0.8.55, from being run on the macOS test runners because it did not build; it said it required md5 support. The version of openssl installed may be so new that it no longer has md5 support, which is deprecated.

I also excluded gcc from being used on the macOS test runners because gcc is not included in macOS. (There is a `gcc` wrapper program but it just runs `clang`.) The Homebrew package manager is preinstalled in the macOS test runners along with several Homebrew packages including several versions of gcc, so if there is a strong desire to test with gcc on macOS it can be done, but it is not usual to use gcc on macOS. Clang is the preferred compiler.

I modified the Install Packages step to only run the `apt` commands on Linux. There is no `apt` on macOS. There is Homebrew (`brew`) but the packages we want are already installed. I figure the versions that are preinstalled are recent enough that I don't need to bother with trying to update them.

I removed `CC=${{ matrix.compiler }}` from the Test step's run section because it is redundant with its env section.

In the matrix section I moved `dynamic` below `nginx` (rather than above) because GitHub Actions seems to generate its job names based on the order in which the variables were defined, which in turn influences the order in which the builds are shown in the results. If this new ordering is not desired I can revert this part of the change. We can also specify the job name explicitly if we want it formatted differently.

I updated the mainline nginx version from 1.21.3 to 1.21.6 and the stable version from 1.20.1 to 1.20.2.

The macOS test runners will fail consistently until #145 is merged and all runners will fail intermittently until #146 is merged. 