### PR TITLE
Fix 404 not found when indexing filesystem root

### DIFF
--- a/ngx_http_fancyindex_module.c
+++ b/ngx_http_fancyindex_module.c
@@ -684,7 +684,10 @@ make_content_buf(
         return NGX_HTTP_INTERNAL_SERVER_ERROR;
 
     allocated = path.len;
-    path.len  = last - path.data - 1;
+    path.len = last - path.data;
+    if (path.len > 1) {
+        path.len--;
+    }
     path.data[path.len] = '\0';
 
     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,

--- a/t/bug107-filesystem-root-404.test
+++ b/t/bug107-filesystem-root-404.test
@@ -1,0 +1,9 @@
+#! /bin/bash
+cat <<---
+Bug #107: 404 is returned when indexing filesystem root
+https://github.com/aperezdc/ngx-fancyindex/issues/107
+--
+nginx_start 'root /;'
+content=$(fetch)
+grep 'Index of /' <<< "${content}"  # It is an index
+grep '<table\>'   <<< "${content}"  # It contains a table


### PR DESCRIPTION
Backport of https://github.com/nginx/nginx/commit/4c89c09ad8e574509446efab0347b124372bc53a

Fixes #107