### PR TITLE
Tests: Make test 02 more specific

### DIFF
--- a/t/02-smoke-indexisfancy.test
+++ b/t/02-smoke-indexisfancy.test
@@ -7,5 +7,5 @@ the fancyindex module.
 nginx_start
 content=$(fetch --with-headers)
 grep 'Index of /' <<< "${content}"  # It is an index
-grep '\<table\>'  <<< "${content}"  # It contains a table
+grep '<table\>'   <<< "${content}"  # It contains a table
 grep '^  Content-Type:[[:space:]]*text/html' <<< "${content}"


### PR DESCRIPTION
Test for an opening `table` tag instead of just the word "table".

(I'm changing `\<` [which means "beginning of word"](https://www.gnu.org/software/grep/manual/html_node/The-Backslash-Character-and-Special-Expressions.html) to just a literal `<`.)