### PR TITLE
Update available distros with module package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,18 +26,15 @@ server written by `Igor Sysoev <http://sysoev.ru>`__.
 Requirements
 ============
 
-CentOS 7
-~~~~~~~~
+CentOS, RHEL, Fedora Linux
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For users of the  `official stable <https://www.nginx.com/resources/wiki/start/topics/tutorials/install/>`__  Nginx repository, `extra packages repository with dynamic modules <https://www.getpagespeed.com/redhat>`__ is available and fancyindex is included.
 
-Install directly:: 
+Install repository configuration, then the module package:: 
 
-    yum install https://extras.getpagespeed.com/redhat/7/x86_64/RPMS/nginx-module-fancyindex-1.12.0.0.4.1-1.el7.gps.x86_64.rpm
-
-Alternatively, add extras repository first (for future updates) and install the module::
-
-    yum install nginx-module-fancyindex
+    yum -y install https://extras.getpagespeed.com/release-latest.rpm
+    yum -y install nginx-module-fancyindex
     
 Then load the module in `/etc/nginx/nginx.conf` using::
 


### PR DESCRIPTION
Fedora Linux has packages available, removed linking to the old NGINX module package version