### PR TITLE
Add missing entry in long weekday names array

### DIFF
--- a/ngx_http_fancyindex_module.c
+++ b/ngx_http_fancyindex_module.c
@@ -37,7 +37,7 @@ static const char *short_weekday[] = {
     "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun",
 };
 static const char *long_weekday[] = {
-    "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Sunday",
+    "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday",
 };
 static const char *short_month[] = {
     "Jan", "Feb", "Mar", "Apr", "May", "Jun",

--- a/t/bug157-saturday-in-long-weekdays.test
+++ b/t/bug157-saturday-in-long-weekdays.test
@@ -1,0 +1,27 @@
+#! /bin/bash
+cat <<---
+Check whether the Saturday long day name is available.
+https://github.com/aperezdc/ngx-fancyindex/issues/157
+--
+use pup
+nginx_start 'fancyindex_time_format "%A"; fancyindex_default_sort date;'
+
+mkdir -p "${TESTDIR}/weekdays"
+for (( i=2 ; i <= 8 ; i++ )) ; do
+	TZ=UTC touch -d "2023-01-0${i}T06:00:00" "${TESTDIR}/weekdays/day$i.txt"
+done
+ls "${TESTDIR}/weekdays"
+content=$(fetch /weekdays/)
+
+# We need row+1 because the first one is the table header.
+dayname=$(pup -p body table tbody \
+	'tr:nth-child(7)' 'td:nth-child(3)' 'text{}' \
+	<<< "$content")
+[[ $dayname = Saturday ]] || fail 'Sixth day is not Saturday'
+
+dayname=$(pup -p body table tbody \
+	'tr:nth-child(8)' 'td:nth-child(3)' 'text{}' \
+	<<< "$content")
+[[ $dayname = Sunday ]] || fail 'Seventh day is not Sunday'
+
+nginx_is_running || fail 'Nginx died'


### PR DESCRIPTION
The entry for Saturday was missing, as pointed out in the bug report. While at it, add a test case.

Fixes #157