### PR TITLE
build-and-run: disable HTTP rewrite module

### DIFF
--- a/t/build-and-run
+++ b/t/build-and-run
@@ -28,6 +28,7 @@ cd nginx-${NGINX}
 ./configure \
 	--add-${DYNAMIC:+dynamic-}module=.. \
 	--with-http_addition_module \
+	--without-http_rewrite_module \
 	--prefix="$(pwd)/../prefix"
 make -j"$JOBS"
 make install


### PR DESCRIPTION
The HTTP rewrite module needs PCRE, which is not available in the GHA MacOS runners. It is unused by the tests, so it's safe to disable building it.